### PR TITLE
Fix starttls bug, update dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: node_js
 node_js:
-  - "6"
+  - "10"

--- a/package.json
+++ b/package.json
@@ -42,11 +42,11 @@
   "author": "Kristijan Sedlak (Xpepermint)",
   "license": "MIT",
   "devDependencies": {
-    "ava": "0.16.x",
+    "ava": "3.11.x",
     "line-buffer": "0.1.x"
   },
   "dependencies": {
-    "promised-timeout": "0.2.x",
+    "promised-timeout": "0.5.x",
     "smtp-channel": "0.2.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -47,6 +47,6 @@
   },
   "dependencies": {
     "promised-timeout": "0.2.x",
-    "smtp-channel": "0.2.2"
+    "smtp-channel": "0.2.3"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -321,13 +321,8 @@ exports.SMTPClient = class extends SMTPChannel {
       else {
         return this.negotiateTLS({timeout});
       }
-    }).then((code) => {
-      if (code.charAt(0) === '2') {
-        return code;
-      }
-      else {
-        throw this._createSMTPResponseError(lines);
-      }
+    }).then(() => {
+      this._extensions = [];
     });
   }
 

--- a/tests/index.js
+++ b/tests/index.js
@@ -68,7 +68,7 @@ test.serial('`connect` throws an error if the response code is not 2xx', async (
 
   let c = new SMTPClient({port: PORT});
 
-  t.throws(c.connect());
+  t.throws(c.connect);
 
   await s.stop();
 });


### PR DESCRIPTION
# starttls bug
There was a bug expecting the `secure` method to return a status code.
While `STARTTLS` does return a status code, this is already handled. If a positive result is recieved, a tls connection is negotiated, otherwise, an error is thrown. However, as the RFC states, the server does not send another status code after the successful negotioation, always leading to a `Cannot read property 'charAt' of undefined` exception in line 325.

Also, as the RFC states, the extensions list has to be reset after `STARTTLS`. This is mandatory because the server will also drop all state, send regular instead of enhanced status codes, leading to all other further method calls to fail if the library tries to decode them as enhanced status codes.

Also, the docs should probably state another `greet()` is required after a call to `secure()` to reestablish the extension list and start a transaction with the mx.

# update dependencies
Also, a bunch of deprecation warnings and some vulnerabilities reported by `npm audit` are fixed by bumping the dependency versions