### PR TITLE
Add support for UTF8 senders/recipients

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -164,10 +164,16 @@ exports.SMTPClient = class extends SMTPChannel {
   * `timeout` parameter.
   */
 
-  mail({from=null, timeout=0}={}) {
+  mail({from=null, timeout=0, utf8=false}={}) {
     let lines = [];
     let handler = (line) => lines.push(line);
     let command = `MAIL FROM:<${from}>\r\n`;
+    if(utf8){
+      if(!this.hasExtension("SMTPUTF8")){
+        throw new Error("Server does not support UTF8 mailboxes");
+      }
+      command = `MAIL FROM:<${from}> SMTPUTF8\r\n`;
+    }
 
     return this.write(command, {timeout, handler}).then((code) => {
       if (code.charAt(0) === '2') {


### PR DESCRIPTION
If the sender or receiver has utf8 characters in their address, then the `MAIL` command must end with `SMTPUTF8`. (if the server supports it) Otherwise, the server will complain when it receives 8 bit data.

Since this library has no knowledge of the recipients when it sends the `MAIL` command (which is fair since this is a "low level" library anyway) we have no way of knowing whether or not we even need to enable `SMTPUTF8` extensions. So that responsibility can fall on the people who end up using this thing.