### PR TITLE
Fix #9, missing dot stuffing

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -292,7 +292,7 @@ exports.SMTPClient = class extends SMTPChannel {
       }
       else {
         lines = [];
-        return this.write(`${source}\r\n.\r\n`, {timeout, handler});
+        return this.write(`${source.replace(/^\./m,'..')}\r\n.\r\n`, {timeout, handler});
       }
     }).then((code) => {
       if (code.charAt(0) === '2') {


### PR DESCRIPTION
Before sending a line of mail text, the SMTP client checks the first
character of the line. If it is a period, one additional period is
inserted at the beginning of the line.

Ref: https://tools.ietf.org/html/rfc5321#section-4.5.2