### PR TITLE
pass timeout to helo/ehlo in greet

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -90,7 +90,7 @@ exports.SMTPClient = class extends SMTPChannel {
   */
 
   greet({hostname=null, timeout=0}={}) {
-    return this.ehlo({hostname}).catch((e) => this.helo({hostname}));
+    return this.ehlo({hostname, timeout}).catch((e) => this.helo({hostname, timeout}));
   }
 
   /*


### PR DESCRIPTION
Right now, the timeout passed to `greet` is disregarded. It should instead be passed to the `ehlo` and `helo` methods.

One downside of this specific implementation is that in the worst case, a call to `greet` will take 2*`timeout` if both methods time out. Instead, something with `setInterval` could be implemented, but I'm not sure whether some cleanup might be required in that case.