### PR TITLE
fix: hasExtension takes type string not string array

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -18,7 +18,7 @@ export class SMTPClient {
   greet(options?: GreetOptions): Promise<void>
   helo(options?: HeloOptions): Promise<void>
   ehlo(options?: EhloOptions): Promise<void>
-  hasExtension(extensions: string[]): boolean
+  hasExtension(extensions: string): boolean
   getDataSizeLimit(): number
   getAuthMechanisms(): string[]
   parseEnhancedReplyCode(line: string): string | null


### PR DESCRIPTION
Error in types.d.ts, ignoring the case issue for now but at least lets make it work in typescript.