### PR TITLE
Add promise.reject when both EHLO and HELO don't work

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "smtp-client",
       "version": "0.4.0",
       "license": "MIT",
       "dependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -89,9 +89,14 @@ exports.SMTPClient = class extends SMTPChannel {
   * number of milliseconds by passing the optional `timeout` parameter.
   */
 
-  greet({hostname=null, timeout=0}={}) {
-    return this.ehlo({hostname, timeout}).catch((e) => this.helo({hostname, timeout}));
+  greet({hostname = null, timeout = 0} = {}) {
+    return this.ehlo({hostname, timeout}).catch((ehloError) =>
+      this.helo({hostname, timeout}).catch((heloError) =>
+          Promise.reject(heloError)
+      )
+    );
   }
+
 
   /*
   * Returns `true` if the provided extension name is supporter by the remote


### PR DESCRIPTION
When both EHLO and HELO don't work, the promise is not rejected which leads to uncaught errors. This PR aims to fix this.