### PR TITLE
Fixes dot-stuffing

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -297,7 +297,7 @@ exports.SMTPClient = class extends SMTPChannel {
       }
       else {
         lines = [];
-        return this.write(`${source.replace(/^\./m,'..')}\r\n.\r\n`, {timeout, handler});
+        return this.write(`${source.replace(/^\./mg,'..')}\r\n.\r\n`, {timeout, handler});
       }
     }).then((code) => {
       if (code.charAt(0) === '2') {


### PR DESCRIPTION
This commit fixes the RegEx that handles dot-stuffing, adding the "global" flag so that it processes the whole input, not just the first occurrence.